### PR TITLE
Fix std::max() error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,6 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+#Vscode
+.vscode/

--- a/Grove_LED_Bar.cpp
+++ b/Grove_LED_Bar.cpp
@@ -148,7 +148,7 @@ void Grove_LED_Bar::setLevel(float level) {
 }
 
 void Grove_LED_Bar::setLed(uint32_t ledNo, float brightness) {
-    ledNo = max(1UL, min(countOfShows, ledNo));
+    ledNo = max((const uint32_t)1, min(countOfShows, ledNo));
     brightness = max(0.0F, min(brightness, 1.0F));
 
     // 8 (noticable) levels of brightness


### PR DESCRIPTION
I had compilation problems with the std::max() function. The change from **unsigned long** to a **const uint32_t** fixed this problem for me, because all the other variables in the std::max() function are **const uint32_t** as well.