### PR TITLE
Use (uint32_t) instead of UL to make the firmware CPU independent

### DIFF
--- a/Grove_LED_Bar.cpp
+++ b/Grove_LED_Bar.cpp
@@ -148,7 +148,7 @@ void Grove_LED_Bar::setLevel(float level) {
 }
 
 void Grove_LED_Bar::setLed(uint32_t ledNo, float brightness) {
-    ledNo = max(1UL, min(countOfShows, ledNo));
+    ledNo = max((uint32_t)1, min(countOfShows, ledNo));
     brightness = max(0.0F, min(brightness, 1.0F));
 
     // 8 (noticable) levels of brightness


### PR DESCRIPTION
I am using `Grove_LED_Bar` with M5Stack and faced the same problem as https://github.com/Seeed-Studio/Grove_LED_Bar/issues/24#issuecomment-945645919 and https://github.com/Seeed-Studio/Grove_LED_Bar/issues/29.

I think the reason is `1UL` is not equivalent to `(uint32_t)`.
Whether these types are equivalent seems to depend on the CPU.
https://stackoverflow.com/questions/35483362/ul-suffix-vs-uint32-t-cast